### PR TITLE
Add runtime-generated post-combat UI for PostCombatFlowService

### DIFF
--- a/Assets/Combat/Scripts/PostBattle/UI/PostCombatBoatRowUI.cs
+++ b/Assets/Combat/Scripts/PostBattle/UI/PostCombatBoatRowUI.cs
@@ -1,0 +1,76 @@
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace MapMode.Scripts.PostBattle
+{
+    public sealed class PostCombatBoatRowUI : MonoBehaviour
+    {
+        public string BoatName { get; private set; }
+        public bool IsSelected => selectionToggle != null && selectionToggle.isOn;
+
+        private Toggle selectionToggle;
+        private Text label;
+
+        public static PostCombatBoatRowUI Create(Transform parent, Font font)
+        {
+            var rowObject = PostCombatUIController.CreateUIObject("BoatRow", parent);
+            rowObject.AddComponent<Image>().color = new Color(1f, 1f, 1f, 0.05f);
+
+            var layout = rowObject.AddComponent<HorizontalLayoutGroup>();
+            layout.padding = new RectOffset(8, 8, 6, 6);
+            layout.spacing = 10f;
+            layout.childControlWidth = false;
+            layout.childForceExpandWidth = false;
+
+            rowObject.AddComponent<LayoutElement>().preferredHeight = 40f;
+
+            var row = rowObject.AddComponent<PostCombatBoatRowUI>();
+            row.Build(font);
+            return row;
+        }
+
+        public void Bind(string boatName, bool defaultSelected)
+        {
+            BoatName = boatName;
+            label.text = boatName;
+            selectionToggle.isOn = defaultSelected;
+        }
+
+        private void Build(Font font)
+        {
+            var toggleObj = PostCombatUIController.CreateUIObject("Toggle", transform);
+            toggleObj.AddComponent<LayoutElement>().preferredWidth = 24f;
+
+            var bg = PostCombatUIController.CreateUIObject("Background", toggleObj.transform);
+            var bgImage = bg.AddComponent<Image>();
+            bgImage.color = new Color(0f, 0f, 0f, 0.45f);
+
+            var checkmark = PostCombatUIController.CreateUIObject("Checkmark", bg.transform);
+            var checkmarkImage = checkmark.AddComponent<Image>();
+            checkmarkImage.color = new Color(0.2f, 0.8f, 0.2f, 1f);
+
+            FitRect(bg.GetComponent<RectTransform>());
+            FitRect(checkmark.GetComponent<RectTransform>(), 4f);
+
+            selectionToggle = toggleObj.AddComponent<Toggle>();
+            selectionToggle.targetGraphic = bgImage;
+            selectionToggle.graphic = checkmarkImage;
+
+            var textObj = PostCombatUIController.CreateUIObject("BoatLabel", transform);
+            label = textObj.AddComponent<Text>();
+            label.font = font;
+            label.color = Color.white;
+            label.alignment = TextAnchor.MiddleLeft;
+
+            textObj.AddComponent<LayoutElement>().preferredWidth = 350f;
+        }
+
+        private static void FitRect(RectTransform rectTransform, float padding = 0f)
+        {
+            rectTransform.anchorMin = Vector2.zero;
+            rectTransform.anchorMax = Vector2.one;
+            rectTransform.offsetMin = new Vector2(padding, padding);
+            rectTransform.offsetMax = new Vector2(-padding, -padding);
+        }
+    }
+}

--- a/Assets/Combat/Scripts/PostBattle/UI/PostCombatLootRowUI.cs
+++ b/Assets/Combat/Scripts/PostBattle/UI/PostCombatLootRowUI.cs
@@ -1,0 +1,119 @@
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace MapMode.Scripts.PostBattle
+{
+    public sealed class PostCombatLootRowUI : MonoBehaviour
+    {
+        public string ItemId { get; private set; }
+
+        private int maxAmount;
+        private InputField amountInput;
+        private Text itemLabel;
+        private Text placeholderLabel;
+
+        public static PostCombatLootRowUI Create(Transform parent, Font font)
+        {
+            var rowObject = PostCombatUIController.CreateUIObject("LootRow", parent);
+            rowObject.AddComponent<Image>().color = new Color(1f, 1f, 1f, 0.05f);
+
+            var rowLayout = rowObject.AddComponent<HorizontalLayoutGroup>();
+            rowLayout.spacing = 8f;
+            rowLayout.padding = new RectOffset(8, 8, 6, 6);
+            rowLayout.childControlWidth = false;
+            rowLayout.childForceExpandWidth = false;
+
+            rowObject.AddComponent<LayoutElement>().preferredHeight = 40f;
+
+            var row = rowObject.AddComponent<PostCombatLootRowUI>();
+            row.Build(font);
+            return row;
+        }
+
+        public void Bind(string itemId, int availableAmount, int defaultAmount)
+        {
+            ItemId = itemId;
+            maxAmount = Mathf.Max(0, availableAmount);
+
+            amountInput.text = Mathf.Clamp(defaultAmount, 0, maxAmount).ToString();
+            placeholderLabel.text = $"0-{maxAmount}";
+            itemLabel.text = $"{itemId} (max {maxAmount})";
+        }
+
+        public int GetSelectedAmount()
+        {
+            if (!int.TryParse(amountInput.text, out var selectedAmount))
+            {
+                selectedAmount = 0;
+            }
+
+            return Mathf.Clamp(selectedAmount, 0, maxAmount);
+        }
+
+        private void Build(Font font)
+        {
+            var nameLabelObject = PostCombatUIController.CreateUIObject("ItemLabel", transform);
+            itemLabel = nameLabelObject.AddComponent<Text>();
+            itemLabel.font = font;
+            itemLabel.color = Color.white;
+            itemLabel.alignment = TextAnchor.MiddleLeft;
+
+            var labelLayout = nameLabelObject.AddComponent<LayoutElement>();
+            labelLayout.preferredWidth = 330f;
+            labelLayout.preferredHeight = 28f;
+
+            var inputObject = PostCombatUIController.CreateUIObject("AmountInput", transform);
+            inputObject.AddComponent<Image>().color = new Color(0f, 0f, 0f, 0.35f);
+            amountInput = inputObject.AddComponent<InputField>();
+
+            var inputLayout = inputObject.AddComponent<LayoutElement>();
+            inputLayout.preferredWidth = 120f;
+            inputLayout.preferredHeight = 30f;
+
+            var textObject = PostCombatUIController.CreateUIObject("Text", inputObject.transform);
+            var text = textObject.AddComponent<Text>();
+            text.font = font;
+            text.color = Color.white;
+            text.alignment = TextAnchor.MiddleLeft;
+
+            StretchToParent(textObject.GetComponent<RectTransform>(), 8f);
+
+            var placeholderObject = PostCombatUIController.CreateUIObject("Placeholder", inputObject.transform);
+            placeholderLabel = placeholderObject.AddComponent<Text>();
+            placeholderLabel.font = font;
+            placeholderLabel.color = new Color(1f, 1f, 1f, 0.45f);
+            placeholderLabel.alignment = TextAnchor.MiddleLeft;
+
+            StretchToParent(placeholderObject.GetComponent<RectTransform>(), 8f);
+
+            amountInput.textComponent = text;
+            amountInput.placeholder = placeholderLabel;
+            amountInput.contentType = InputField.ContentType.IntegerNumber;
+            amountInput.lineType = InputField.LineType.SingleLine;
+            amountInput.characterLimit = 8;
+            amountInput.onValueChanged.AddListener(OnAmountChanged);
+        }
+
+        private void OnAmountChanged(string input)
+        {
+            if (!int.TryParse(input, out var selectedAmount))
+            {
+                return;
+            }
+
+            var clamped = Mathf.Clamp(selectedAmount, 0, maxAmount);
+            if (clamped.ToString() != input)
+            {
+                amountInput.SetTextWithoutNotify(clamped.ToString());
+            }
+        }
+
+        private static void StretchToParent(RectTransform rectTransform, float horizontalPadding)
+        {
+            rectTransform.anchorMin = Vector2.zero;
+            rectTransform.anchorMax = Vector2.one;
+            rectTransform.offsetMin = new Vector2(horizontalPadding, 0f);
+            rectTransform.offsetMax = new Vector2(-horizontalPadding, 0f);
+        }
+    }
+}

--- a/Assets/Combat/Scripts/PostBattle/UI/PostCombatUIBootstrap.cs
+++ b/Assets/Combat/Scripts/PostBattle/UI/PostCombatUIBootstrap.cs
@@ -1,0 +1,21 @@
+using UnityEngine;
+
+namespace MapMode.Scripts.PostBattle
+{
+    public static class PostCombatUIBootstrap
+    {
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterSceneLoad)]
+        private static void EnsurePostCombatUIExists()
+        {
+            var existingController = Object.FindObjectOfType<PostCombatUIController>();
+            if (existingController != null)
+            {
+                return;
+            }
+
+            var uiObject = new GameObject("PostCombatUI");
+            Object.DontDestroyOnLoad(uiObject);
+            uiObject.AddComponent<PostCombatUIController>();
+        }
+    }
+}

--- a/Assets/Combat/Scripts/PostBattle/UI/PostCombatUIController.cs
+++ b/Assets/Combat/Scripts/PostBattle/UI/PostCombatUIController.cs
@@ -1,0 +1,267 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace MapMode.Scripts.PostBattle
+{
+    public sealed class PostCombatUIController : MonoBehaviour
+    {
+        private const string GoldLootKey = "gold";
+
+        private Font uiFont;
+        private GameObject panelRoot;
+        private Text goldRewardLabel;
+        private Transform lootContainer;
+        private Transform boatsContainer;
+        private Button confirmButton;
+
+        private readonly List<PostCombatLootRowUI> lootRows = new List<PostCombatLootRowUI>();
+        private readonly List<PostCombatBoatRowUI> boatRows = new List<PostCombatBoatRowUI>();
+
+        private void Awake()
+        {
+            BuildUIIfNeeded();
+            HidePanel();
+        }
+
+        private void OnEnable()
+        {
+            PostCombatFlowService.PostCombatReady += OnPostCombatReady;
+
+            if (PostCombatFlowService.IsPostCombatActive && PostCombatFlowService.CurrentPostCombatData != null)
+            {
+                OnPostCombatReady(PostCombatFlowService.CurrentPostCombatData);
+            }
+        }
+
+        private void OnDisable()
+        {
+            PostCombatFlowService.PostCombatReady -= OnPostCombatReady;
+        }
+
+        private void OnPostCombatReady(PostCombatData data)
+        {
+            if (data == null)
+            {
+                return;
+            }
+
+            BuildUIIfNeeded();
+            Populate(data);
+            panelRoot.SetActive(true);
+        }
+
+        private void Populate(PostCombatData data)
+        {
+            goldRewardLabel.text = $"Gold Reward: {data.GoldReward}";
+
+            ClearRows();
+
+            foreach (var lootKvp in data.AvailableLoot)
+            {
+                var row = PostCombatLootRowUI.Create(lootContainer, uiFont);
+                var defaultAmount = string.Equals(lootKvp.Key, GoldLootKey, StringComparison.OrdinalIgnoreCase)
+                    ? lootKvp.Value
+                    : 0;
+
+                row.Bind(lootKvp.Key, lootKvp.Value, defaultAmount);
+                lootRows.Add(row);
+            }
+
+            foreach (var boat in data.CapturableBoats)
+            {
+                if (boat == null)
+                {
+                    continue;
+                }
+
+                var row = PostCombatBoatRowUI.Create(boatsContainer, uiFont);
+                row.Bind(boat.boatName, false);
+                boatRows.Add(row);
+            }
+        }
+
+        private void OnConfirmPressed()
+        {
+            var selectedLoot = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+            foreach (var row in lootRows)
+            {
+                if (row == null)
+                {
+                    continue;
+                }
+
+                selectedLoot[row.ItemId] = row.GetSelectedAmount();
+            }
+
+            var selectedBoats = new List<string>();
+            foreach (var row in boatRows)
+            {
+                if (row != null && row.IsSelected)
+                {
+                    selectedBoats.Add(row.BoatName);
+                }
+            }
+
+            PostCombatFlowService.ResolvePostCombat(new PostCombatSelection(selectedLoot, selectedBoats));
+
+            ClearRows();
+            HidePanel();
+        }
+
+        private void BuildUIIfNeeded()
+        {
+            if (panelRoot != null)
+            {
+                return;
+            }
+
+            uiFont = Resources.GetBuiltinResource<Font>("Arial.ttf");
+
+            var canvas = EnsureCanvas();
+            EnsureEventSystem();
+
+            panelRoot = CreateUIObject("PostCombatPanel", canvas.transform);
+            var panelImage = panelRoot.AddComponent<Image>();
+            panelImage.color = new Color(0f, 0f, 0f, 0.85f);
+
+            var panelRect = panelRoot.GetComponent<RectTransform>();
+            panelRect.anchorMin = new Vector2(0.15f, 0.1f);
+            panelRect.anchorMax = new Vector2(0.85f, 0.9f);
+            panelRect.offsetMin = Vector2.zero;
+            panelRect.offsetMax = Vector2.zero;
+
+            var panelLayout = panelRoot.AddComponent<VerticalLayoutGroup>();
+            panelLayout.padding = new RectOffset(20, 20, 20, 20);
+            panelLayout.spacing = 12f;
+            panelLayout.childControlWidth = true;
+            panelLayout.childControlHeight = false;
+            panelLayout.childForceExpandHeight = false;
+
+            panelRoot.AddComponent<ContentSizeFitter>().verticalFit = ContentSizeFitter.FitMode.PreferredSize;
+
+            CreateLabel("Post Combat", panelRoot.transform, 32, TextAnchor.MiddleCenter);
+            goldRewardLabel = CreateLabel("Gold Reward: 0", panelRoot.transform, 22, TextAnchor.MiddleLeft);
+
+            CreateLabel("Available Loot", panelRoot.transform, 24, TextAnchor.MiddleLeft);
+            lootContainer = CreateListContainer("LootContainer", panelRoot.transform);
+
+            CreateLabel("Capturable Boats", panelRoot.transform, 24, TextAnchor.MiddleLeft);
+            boatsContainer = CreateListContainer("BoatsContainer", panelRoot.transform);
+
+            var buttonObj = CreateUIObject("ConfirmButton", panelRoot.transform);
+            var buttonImage = buttonObj.AddComponent<Image>();
+            buttonImage.color = new Color(0.18f, 0.4f, 0.18f, 1f);
+
+            confirmButton = buttonObj.AddComponent<Button>();
+            confirmButton.onClick.AddListener(OnConfirmPressed);
+
+            var buttonRect = buttonObj.GetComponent<RectTransform>();
+            buttonRect.sizeDelta = new Vector2(0f, 48f);
+            buttonObj.AddComponent<LayoutElement>().preferredHeight = 48f;
+
+            CreateLabel("Confirm", buttonObj.transform, 20, TextAnchor.MiddleCenter);
+        }
+
+        private void HidePanel()
+        {
+            if (panelRoot != null)
+            {
+                panelRoot.SetActive(false);
+            }
+        }
+
+        private void ClearRows()
+        {
+            foreach (var row in lootRows)
+            {
+                if (row != null)
+                {
+                    Destroy(row.gameObject);
+                }
+            }
+
+            foreach (var row in boatRows)
+            {
+                if (row != null)
+                {
+                    Destroy(row.gameObject);
+                }
+            }
+
+            lootRows.Clear();
+            boatRows.Clear();
+        }
+
+        private Canvas EnsureCanvas()
+        {
+            var existingCanvas = FindObjectOfType<Canvas>();
+            if (existingCanvas != null)
+            {
+                return existingCanvas;
+            }
+
+            var canvasObject = new GameObject("PostCombatCanvas", typeof(RectTransform), typeof(Canvas), typeof(CanvasScaler), typeof(GraphicRaycaster));
+            var canvas = canvasObject.GetComponent<Canvas>();
+            canvas.renderMode = RenderMode.ScreenSpaceOverlay;
+
+            var scaler = canvasObject.GetComponent<CanvasScaler>();
+            scaler.uiScaleMode = CanvasScaler.ScaleMode.ScaleWithScreenSize;
+            scaler.referenceResolution = new Vector2(1920, 1080);
+
+            return canvas;
+        }
+
+        private static void EnsureEventSystem()
+        {
+            if (FindObjectOfType<UnityEngine.EventSystems.EventSystem>() != null)
+            {
+                return;
+            }
+
+            var eventSystemObject = new GameObject("EventSystem", typeof(UnityEngine.EventSystems.EventSystem), typeof(UnityEngine.EventSystems.StandaloneInputModule));
+            DontDestroyOnLoad(eventSystemObject);
+        }
+
+        private Transform CreateListContainer(string objectName, Transform parent)
+        {
+            var container = CreateUIObject(objectName, parent);
+
+            var layout = container.AddComponent<VerticalLayoutGroup>();
+            layout.spacing = 6f;
+            layout.childControlHeight = true;
+            layout.childControlWidth = true;
+            layout.childForceExpandHeight = false;
+
+            var contentSize = container.AddComponent<ContentSizeFitter>();
+            contentSize.verticalFit = ContentSizeFitter.FitMode.PreferredSize;
+
+            container.AddComponent<LayoutElement>().preferredHeight = 120f;
+            return container.transform;
+        }
+
+        private Text CreateLabel(string text, Transform parent, int fontSize, TextAnchor alignment)
+        {
+            var labelObject = CreateUIObject($"Label_{text}", parent);
+            var label = labelObject.AddComponent<Text>();
+            label.font = uiFont;
+            label.text = text;
+            label.fontSize = fontSize;
+            label.color = Color.white;
+            label.alignment = alignment;
+
+            var layoutElement = labelObject.AddComponent<LayoutElement>();
+            layoutElement.preferredHeight = fontSize + 12f;
+
+            return label;
+        }
+
+        internal static GameObject CreateUIObject(string name, Transform parent)
+        {
+            var go = new GameObject(name, typeof(RectTransform));
+            go.transform.SetParent(parent, false);
+            return go;
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide an in-game UI that displays post-combat results and lets the player pick loot amounts and which enemy boats to capture when `PostCombatFlowService` raises `PostCombatReady`.
- Make the UI self-contained and createable at runtime so scenes do not need manual wiring or prefab placement.

### Description
- Added `PostCombatUIBootstrap` which ensures a persistent `PostCombatUIController` exists after scenes load and launches the UI flow automatically.
- Implemented `PostCombatUIController` that subscribes to `PostCombatFlowService.PostCombatReady`, builds a Canvas/EventSystem and a panel with labels, loot and boat containers, and a confirm button at runtime, and calls `PostCombatFlowService.ResolvePostCombat(...)` with the player’s selections.
- Added `PostCombatLootRowUI` to render a loot row with an `InputField`, integer clamping, and default selection behavior (items named `gold` default to taking full amount).
- Added `PostCombatBoatRowUI` to render capturable-boat rows with a `Toggle` so players can choose which boats to capture.

### Testing
- No automated Unity editor or playmode tests were executed in this environment; the change adds runtime UI scripts intended to be validated in the Unity editor or during playtests.
- All new source files were created and saved under `Assets/Combat/Scripts/PostBattle/UI/` for in-editor verification and testing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b37bca59a48333a7bc0f7e05ef6505)