### PR TITLE
Refactor town UI to context-driven, inspector-wired architecture

### DIFF
--- a/Assets/MapMode/Scripts/DataTypes/Town.cs
+++ b/Assets/MapMode/Scripts/DataTypes/Town.cs
@@ -59,19 +59,13 @@ public class Town : MonoBehaviour
     Dictionary<int, (int,float,string)> incomingFleets = new Dictionary<int, (int, float,string)>();//incoming fleet id, amount its carrying, expected time till it arrives
     public List<Fleet> dockedFleets = new List<Fleet>();
 
-    private TownInfoUI townUI;
+    [SerializeField] private TownInfoUI townUI;
     private float _productionTimer=0;
-    private Town _town;
 
     #endregion
 
     #region Monobehaviour
 
-    private void Awake()
-    {
-        _town = gameObject.GetComponent<Town>();
-        townUI = GameObject.Find("TownOverview").GetComponent<TownInfoUI>();
-    }
     void Start()
     {
         GameEvents.SaveInitiated += Save;// add events to happen when save and load is called
@@ -122,11 +116,17 @@ public class Town : MonoBehaviour
 
     private void OnMouseOver()
     {
-        townUI.DisplayTownUI(gameObject.GetComponent<Town>());
+        if (townUI != null)
+        {
+            townUI.DisplayTownUI(this);
+        }
     }
     private void OnMouseExit()
     {
-        townUI.CloseTownUI();
+        if (townUI != null)
+        {
+            townUI.CloseTownUI();
+        }
     }
 
 
@@ -217,7 +217,7 @@ public class Town : MonoBehaviour
             else
                 amountWant = 800;
 
-            (Fleet, int) sentOutFleet = townManager.RequestItemNonSurplus(itemToRequest.Item2, amountWant, _town);
+            (Fleet, int) sentOutFleet = townManager.RequestItemNonSurplus(itemToRequest.Item2, amountWant, this);
 
             if (sentOutFleet.Item2 > 0 && sentOutFleet.Item1 != null) {
                 StartCoroutine(RunExpected(itemToRequest.Item2, sentOutFleet.Item2, sentOutFleet.Item1));

--- a/Assets/MapMode/Scripts/PlayerFleetMapController.cs
+++ b/Assets/MapMode/Scripts/PlayerFleetMapController.cs
@@ -15,14 +15,12 @@ public class PlayerFleetMapController : MonoBehaviour
         public float[] pos;
     }
 
-    public GameObject Canvas;
-    private MeetShipUI meetShipUI;
-    private TownUI townUI;
-    private TownOptionsUI townOptionsUI;
+    [SerializeField] private MeetShipUI meetShipUI;
+    [SerializeField] private TownOptionsUI townOptionsUI;
+    [SerializeField] private TownUIContext townUIContext;
 
     public NavMeshAgent navAgent;
     public Transform target;
-    public static Town currentTown;
     
     [TextArea]
     public string _boatNames = "";
@@ -50,10 +48,6 @@ public class PlayerFleetMapController : MonoBehaviour
 
         UpdateBoatNames();
 
-        meetShipUI = Canvas.transform.Find("MeetShip").GetComponent<MeetShipUI>();
-        townUI = GameObject.Find("ShopPanel").GetComponent<TownUI>();
-        townOptionsUI = GameObject.Find("TownOptions").GetComponent<TownOptionsUI>();
-
     }
     private void Update()
     {
@@ -74,8 +68,8 @@ public class PlayerFleetMapController : MonoBehaviour
 
         }
         else if (town != null) {
+            townUIContext.SetContext(town, PlayerStateService.PlayerFleet);
             townOptionsUI.DisplayOptionsMenu(town);
-            currentTown = town;
             TownEvents.InvokeTownVisited(town);
             GameEvents.SaveGame();
         }

--- a/Assets/MapMode/Scripts/UIScripts/ShopUI.cs
+++ b/Assets/MapMode/Scripts/UIScripts/ShopUI.cs
@@ -1,17 +1,16 @@
-﻿using System;
-using System.Collections;
-using System.Collections.Generic;
 using TMPro;
 using UnityEngine;
 using UnityEngine.UI;
 
 public class ShopUI : MonoBehaviour
 {
+    [Header("Context")]
+    [SerializeField] private TownUIContext townUIContext;
+
     private Town town;
     private Fleet fleet;
     private string ogPrice;
     private string ogPriceSell;
-
 
     [Header("Buy Panel Objects")]
     public Transform scrollViewContent;
@@ -24,6 +23,7 @@ public class ShopUI : MonoBehaviour
     public TMP_Text itemName;
     public Button purchaseBtn;
     public GameObject buyMode;
+
     [Header("Sell Panel Objects")]
     public Transform scrollViewContentSell;
     public GameObject sellMode;
@@ -33,224 +33,201 @@ public class ShopUI : MonoBehaviour
     public Image itemInfoImageSell;
     public TMP_Text itemDescriptionSell;
     public TMP_Text itemNameSell;
+
     [Header("Inventory")]
     public Image inventoryIconPrefab;
     public Text inventoryItemNamePrefab;
     public Text inventoryNumberPrefab;
     public Sprite[] inventoryIcons;
     public Transform inventoryScrollViewContent;
+
     [Header("Choice Buttons")]
     public Button buyButton;
     public Button sellButton;
+
+    private void OnEnable()
+    {
+        if (townUIContext != null)
+        {
+            townUIContext.ContextChanged += HandleContextChanged;
+        }
+    }
+
+    private void OnDisable()
+    {
+        if (townUIContext != null)
+        {
+            townUIContext.ContextChanged -= HandleContextChanged;
+        }
+    }
+
     private void Start()
     {
-        fleet = GameObject.Find("PlayerBoat").GetComponent<PlayerFleetMapController>().GetFleet();
-        displayBuyTab(PlayerFleetMapController.currentTown);
         purchaseBtn.interactable = false;
-        sellBtn.interactable=false;
+        sellBtn.interactable = false;
+
+        if (townUIContext == null)
+        {
+            Debug.LogError($"[{nameof(ShopUI)}] Missing {nameof(TownUIContext)} reference.");
+            enabled = false;
+            return;
+        }
+
+        HandleContextChanged(townUIContext.CurrentTown, townUIContext.CurrentFleet);
         playerMoney.text = PlayerStateService.Money.ToString();
-        fillInventoryBuyPage();
     }
+
     private void Update()
     {
         playerMoney.text = PlayerStateService.Money.ToString();
     }
 
-    public void displayBuyTab(Town t)
+    private void HandleContextChanged(Town newTown, Fleet newFleet)
     {
+        town = newTown;
+        fleet = newFleet;
 
-        foreach (Transform contentChild in scrollViewContent.transform)
+        if (town == null || fleet == null)
         {
-            Destroy(contentChild.gameObject);
+            return;
         }
 
-
-        buyMode.SetActive(true);
-        sellMode.SetActive(false);
-
-        string townName = t.name;
-        town = t;
-        (string[], int[], int[], float[]) itemInfo = t.SupplyDemandPrice();
-        Debug.Log(townName);
-
-        for (int i = 0; i < itemInfo.Item1.Length; i++)
-        {
-            GameObject buyPanel = Instantiate(buyInfoPanel);
-            Button itemButton = buyPanel.GetComponent<Button>();
-            itemButton.onClick.AddListener(() => { displayItemInfo(itemButton);});
-
-            buyPanel.transform.GetChild(0).GetComponent<Image>().sprite = t.setupSupplyIcons[i];
-             buyPanel.transform.GetChild(1).GetComponent<TMP_Text>().text = itemInfo.Item1[i];
-             buyPanel.transform.GetChild(2).GetComponent<TMP_Text>().text = itemInfo.Item2[i].ToString();
-             buyPanel.transform.GetChild(3).GetComponent<TMP_Text>().text = itemInfo.Item3[i].ToString();
-             buyPanel.transform.GetChild(4).GetComponent<TMP_Text>().text = itemInfo.Item4[i].ToString();
-
-            buyPanel.transform.SetParent(scrollViewContent, false);
-
-            if (i == 0)
-            {
-                itemButton.onClick.Invoke();
-            }
-
-        }
-
+        displayBuyTab(town);
+        fillInventoryBuyPage();
     }
+
+    public void displayBuyTab(Town selectedTown)
+    {
+        if (selectedTown == null)
+        {
+            return;
+        }
+
+        town = selectedTown;
+        PopulateTradeList(scrollViewContent, true);
+    }
+
     public void displayBuyTabBtn()
     {
-        foreach (Transform contentChild in scrollViewContent.transform)
+        if (town == null)
         {
-            Destroy(contentChild.gameObject);
+            return;
         }
 
-
-        buyMode.SetActive(true);
-        sellMode.SetActive(false);
-
-
-        town = PlayerFleetMapController.currentTown;
-        string townName = town.name;
-        (string[], int[], int[], float[]) itemInfo = town.SupplyDemandPrice();
-
-        for (int i = 0; i < itemInfo.Item1.Length; i++)
-        {
-            GameObject buyPanel = Instantiate(buyInfoPanel);
-            Button itemButton = buyPanel.GetComponent<Button>();
-            itemButton.onClick.AddListener(() => { displayItemInfo(itemButton); });
-
-            buyPanel.transform.GetChild(0).GetComponent<Image>().sprite = town.setupSupplyIcons[i];
-            buyPanel.transform.GetChild(1).GetComponent<TMP_Text>().text = itemInfo.Item1[i];
-            buyPanel.transform.GetChild(2).GetComponent<TMP_Text>().text = itemInfo.Item2[i].ToString();
-            buyPanel.transform.GetChild(3).GetComponent<TMP_Text>().text = itemInfo.Item3[i].ToString();
-            buyPanel.transform.GetChild(4).GetComponent<TMP_Text>().text = itemInfo.Item4[i].ToString();
-
-            buyPanel.transform.SetParent(scrollViewContent, false);
-            if(i == 0)
-            {
-                itemButton.onClick.Invoke();
-            }
-
-        }
-
+        PopulateTradeList(scrollViewContent, true);
     }
 
     public void displaySellTab()
     {
-        foreach (Transform contentChild in scrollViewContentSell.transform)
+        if (town == null)
+        {
+            return;
+        }
+
+        PopulateTradeList(scrollViewContentSell, false);
+    }
+
+    private void PopulateTradeList(Transform container, bool isBuy)
+    {
+        foreach (Transform contentChild in container)
         {
             Destroy(contentChild.gameObject);
         }
 
-        buyMode.SetActive(false);
-        sellMode.SetActive(true);
+        buyMode.SetActive(isBuy);
+        sellMode.SetActive(!isBuy);
 
+        (string[] itemNames, int[] supply, int[] demand, float[] prices) = town.SupplyDemandPrice();
 
-
-        town = PlayerFleetMapController.currentTown;
-        string townName = town.name;
-        (string[], int[], int[], float[]) itemInfo = town.SupplyDemandPrice();
-
-        for (int i = 0; i < itemInfo.Item1.Length; i++)
+        for (int i = 0; i < itemNames.Length; i++)
         {
-            GameObject buyPanel = Instantiate(buyInfoPanel);
-            Button itemButton = buyPanel.GetComponent<Button>();
-            itemButton.onClick.AddListener(() => { displayItemInfoSell(itemButton); });
+            GameObject panel = Instantiate(buyInfoPanel, container, false);
+            Button itemButton = panel.GetComponent<Button>();
 
-            buyPanel.transform.GetChild(0).GetComponent<Image>().sprite = town.setupSupplyIcons[i];
-            buyPanel.transform.GetChild(1).GetComponent<TMP_Text>().text = itemInfo.Item1[i];
-            buyPanel.transform.GetChild(2).GetComponent<TMP_Text>().text = itemInfo.Item2[i].ToString();
-            buyPanel.transform.GetChild(3).GetComponent<TMP_Text>().text = itemInfo.Item3[i].ToString();
-            buyPanel.transform.GetChild(4).GetComponent<TMP_Text>().text = itemInfo.Item4[i].ToString();
+            int index = i;
+            if (isBuy)
+            {
+                itemButton.onClick.AddListener(() => displayItemInfo(itemButton));
+            }
+            else
+            {
+                itemButton.onClick.AddListener(() => displayItemInfoSell(itemButton));
+            }
 
-            buyPanel.transform.SetParent(scrollViewContentSell, false);
+            panel.transform.GetChild(0).GetComponent<Image>().sprite = town.setupSupplyIcons[index];
+            panel.transform.GetChild(1).GetComponent<TMP_Text>().text = itemNames[index];
+            panel.transform.GetChild(2).GetComponent<TMP_Text>().text = supply[index].ToString();
+            panel.transform.GetChild(3).GetComponent<TMP_Text>().text = demand[index].ToString();
+            panel.transform.GetChild(4).GetComponent<TMP_Text>().text = prices[index].ToString();
 
             if (i == 0)
             {
                 itemButton.onClick.Invoke();
             }
         }
-
     }
 
     public void increaseItemAmount()
     {
-        int inputAmount;
-        if(buyMode.activeSelf == true)
+        if (buyMode.activeSelf)
         {
-            inputAmount = int.Parse(itemAmountInputField.text) + 1;
-            itemAmountInputField.text = inputAmount.ToString();
-        }
-        if(sellMode.activeSelf == true)
-        {
-            inputAmount = int.Parse(itemSellAmountInputField.text) + 1;
-            itemSellAmountInputField.text = inputAmount.ToString();
+            itemAmountInputField.text = (int.Parse(itemAmountInputField.text) + 1).ToString();
         }
 
-        
+        if (sellMode.activeSelf)
+        {
+            itemSellAmountInputField.text = (int.Parse(itemSellAmountInputField.text) + 1).ToString();
+        }
     }
 
     public void decreaseItemAmount()
     {
-        int inputAmount;
-
-        if(int.Parse(itemAmountInputField.text) > 0)
+        if (buyMode.activeSelf && int.Parse(itemAmountInputField.text) > 0)
         {
-            if (buyMode.activeSelf == true)
-            {
-                inputAmount = int.Parse(itemAmountInputField.text) - 1;
-                itemAmountInputField.text = inputAmount.ToString();
-            }
-            if (sellMode.activeSelf == true)
-            {
-                inputAmount = int.Parse(itemSellAmountInputField.text) - 1;
-                itemSellAmountInputField.text = inputAmount.ToString();
-            }
+            itemAmountInputField.text = (int.Parse(itemAmountInputField.text) - 1).ToString();
+        }
+
+        if (sellMode.activeSelf && int.Parse(itemSellAmountInputField.text) > 0)
+        {
+            itemSellAmountInputField.text = (int.Parse(itemSellAmountInputField.text) - 1).ToString();
         }
     }
 
     public void multiplyPrice()
     {
-        float multiplePrice;
-        if(itemAmountInputField.text != "")
+        if (itemAmountInputField.text == "")
         {
-            multiplePrice = int.Parse(itemAmountInputField.text) * float.Parse(ogPrice);
-            priceText.text = multiplePrice.ToString();
-
-            if ((PlayerStateService.Money - multiplePrice) >= 0)
-            {
-                purchaseBtn.interactable = true;
-            }
-            else
-            {
-                purchaseBtn.interactable = false;
-            }
+            return;
         }
 
+        float multiplePrice = int.Parse(itemAmountInputField.text) * float.Parse(ogPrice);
+        priceText.text = multiplePrice.ToString();
+        purchaseBtn.interactable = (PlayerStateService.Money - multiplePrice) >= 0;
     }
 
     public void multiplySellPrice()
     {
-        float multiplePrice;
-        if(itemSellAmountInputField.text != "")
+        if (itemSellAmountInputField.text == "")
         {
-            multiplePrice = int.Parse(itemSellAmountInputField.text) * float.Parse(ogPriceSell);
-            sellPriceText.text = multiplePrice.ToString();
-
-            (string[], int[]) inventoryContent = fleet.GetInventory();
-            for(int i =0; i<inventoryContent.Item1.Length; i++)
-            {
-                if (inventoryContent.Item1[i].ToLower().Equals(itemNameSell.text.ToLower())){
-                    if(int.Parse(itemSellAmountInputField.text) > inventoryContent.Item2[i])
-                    {
-                        sellBtn.interactable = false;
-                    }
-                    else
-                    {
-                        sellBtn.interactable = true;
-                    }
-                }
-            }
+            return;
         }
 
+        float multiplePrice = int.Parse(itemSellAmountInputField.text) * float.Parse(ogPriceSell);
+        sellPriceText.text = multiplePrice.ToString();
+
+        (string[] names, int[] amounts) inventoryContent = fleet.GetInventory();
+        for (int i = 0; i < inventoryContent.names.Length; i++)
+        {
+            if (!inventoryContent.names[i].ToLower().Equals(itemNameSell.text.ToLower()))
+            {
+                continue;
+            }
+
+            sellBtn.interactable = int.Parse(itemSellAmountInputField.text) <= inventoryContent.amounts[i];
+            return;
+        }
+
+        sellBtn.interactable = false;
     }
 
     public void displayItemInfo(Button itemPanel)
@@ -258,49 +235,12 @@ public class ShopUI : MonoBehaviour
         itemAmountInputField.text = "";
 
         ogPrice = itemPanel.transform.GetChild(4).GetComponent<TMP_Text>().text;
-        priceText.text = itemPanel.transform.GetChild(4).GetComponent<TMP_Text>().text;
+        priceText.text = ogPrice;
         itemInfoImage.sprite = itemPanel.transform.GetChild(0).GetComponent<Image>().sprite;
-        itemName.text = itemPanel.transform.GetChild(1).GetComponent<TMP_Text>().text;
 
-        if (itemPanel.transform.GetChild(1).GetComponent<TMP_Text>().text == "fish")
-        {
-            itemDescription.text = PlayerFleetMapController.currentTown.setupSupplyDescription[0];
-        }else if (itemPanel.transform.GetChild(1).GetComponent<TMP_Text>().text == "lumber")
-        {
-            itemDescription.text = PlayerFleetMapController.currentTown.setupSupplyDescription[1];
-        }
-        else if (itemPanel.transform.GetChild(1).GetComponent<TMP_Text>().text == "fur")
-        {
-            itemDescription.text = PlayerFleetMapController.currentTown.setupSupplyDescription[2];
-        }
-        else if (itemPanel.transform.GetChild(1).GetComponent<TMP_Text>().text == "guns")
-        {
-            itemDescription.text = PlayerFleetMapController.currentTown.setupSupplyDescription[3];
-        }
-        else if (itemPanel.transform.GetChild(1).GetComponent<TMP_Text>().text == "sugar")
-        {
-            itemDescription.text = PlayerFleetMapController.currentTown.setupSupplyDescription[4];
-        }
-        else if (itemPanel.transform.GetChild(1).GetComponent<TMP_Text>().text == "coffee")
-        {
-            itemDescription.text = PlayerFleetMapController.currentTown.setupSupplyDescription[5];
-        }
-        else if (itemPanel.transform.GetChild(1).GetComponent<TMP_Text>().text == "salt")
-        {
-            itemDescription.text = PlayerFleetMapController.currentTown.setupSupplyDescription[6];
-        }
-        else if (itemPanel.transform.GetChild(1).GetComponent<TMP_Text>().text == "tea")
-        {
-            itemDescription.text = PlayerFleetMapController.currentTown.setupSupplyDescription[7];
-        }
-        else if (itemPanel.transform.GetChild(1).GetComponent<TMP_Text>().text == "tobacco")
-        {
-            itemDescription.text = PlayerFleetMapController.currentTown.setupSupplyDescription[8];
-        }
-        else if (itemPanel.transform.GetChild(1).GetComponent<TMP_Text>().text == "cotton")
-        {
-            itemDescription.text = PlayerFleetMapController.currentTown.setupSupplyDescription[9];
-        }
+        string selectedItemName = itemPanel.transform.GetChild(1).GetComponent<TMP_Text>().text;
+        itemName.text = selectedItemName;
+        itemDescription.text = GetItemDescription(selectedItemName);
     }
 
     public void displayItemInfoSell(Button itemPanel)
@@ -308,58 +248,25 @@ public class ShopUI : MonoBehaviour
         itemSellAmountInputField.text = "";
 
         ogPriceSell = itemPanel.transform.GetChild(4).GetComponent<TMP_Text>().text;
-        sellPriceText.text = itemPanel.transform.GetChild(4).GetComponent<TMP_Text>().text;
+        sellPriceText.text = ogPriceSell;
         itemInfoImageSell.sprite = itemPanel.transform.GetChild(0).GetComponent<Image>().sprite;
-        itemNameSell.text = itemPanel.transform.GetChild(1).GetComponent<TMP_Text>().text;
 
-        if (itemPanel.transform.GetChild(1).GetComponent<TMP_Text>().text == "fish")
-        {
-            itemDescriptionSell.text = PlayerFleetMapController.currentTown.setupSupplyDescription[0];
-        }
-        else if (itemPanel.transform.GetChild(1).GetComponent<TMP_Text>().text == "lumber")
-        {
-            itemDescriptionSell.text = PlayerFleetMapController.currentTown.setupSupplyDescription[1];
-        }
-        else if (itemPanel.transform.GetChild(1).GetComponent<TMP_Text>().text == "fur")
-        {
-            itemDescriptionSell.text = PlayerFleetMapController.currentTown.setupSupplyDescription[2];
-        }
-        else if (itemPanel.transform.GetChild(1).GetComponent<TMP_Text>().text == "guns")
-        {
-            itemDescriptionSell.text = PlayerFleetMapController.currentTown.setupSupplyDescription[3];
-        }
-        else if (itemPanel.transform.GetChild(1).GetComponent<TMP_Text>().text == "sugar")
-        {
-            itemDescriptionSell.text = PlayerFleetMapController.currentTown.setupSupplyDescription[4];
-        }
-        else if (itemPanel.transform.GetChild(1).GetComponent<TMP_Text>().text == "coffee")
-        {
-            itemDescriptionSell.text = PlayerFleetMapController.currentTown.setupSupplyDescription[5];
-        }
-        else if (itemPanel.transform.GetChild(1).GetComponent<TMP_Text>().text == "salt")
-        {
-            itemDescriptionSell.text = PlayerFleetMapController.currentTown.setupSupplyDescription[6];
-        }
-        else if (itemPanel.transform.GetChild(1).GetComponent<TMP_Text>().text == "tea")
-        {
-            itemDescriptionSell.text = PlayerFleetMapController.currentTown.setupSupplyDescription[7];
-        }
-        else if (itemPanel.transform.GetChild(1).GetComponent<TMP_Text>().text == "tobacco")
-        {
-            itemDescriptionSell.text = PlayerFleetMapController.currentTown.setupSupplyDescription[8];
-        }
-        else if (itemPanel.transform.GetChild(1).GetComponent<TMP_Text>().text == "cotton")
-        {
-            itemDescriptionSell.text = PlayerFleetMapController.currentTown.setupSupplyDescription[9];
-        }
+        string selectedItemName = itemPanel.transform.GetChild(1).GetComponent<TMP_Text>().text;
+        itemNameSell.text = selectedItemName;
+        itemDescriptionSell.text = GetItemDescription(selectedItemName);
     }
 
     public void purchaseItem()
     {
+        if (town == null || fleet == null)
+        {
+            return;
+        }
+
         int itemAmount = int.Parse(itemAmountInputField.text);
         float price = float.Parse(priceText.text);
 
-        PlayerFleetMapController.currentTown.FillCargoPlayer(fleet, itemName.text, itemAmount);
+        town.FillCargoPlayer(fleet, itemName.text, itemAmount);
         if (PlayerStateService.TrySpendMoney(price))
         {
             fillInventoryBuyPage();
@@ -368,10 +275,15 @@ public class ShopUI : MonoBehaviour
 
     public void sellItem()
     {
+        if (town == null || fleet == null)
+        {
+            return;
+        }
+
         int itemAmount = int.Parse(itemSellAmountInputField.text);
         float price = float.Parse(sellPriceText.text);
 
-        PlayerFleetMapController.currentTown.SellItemsInCargo(fleet, itemAmount, itemNameSell.text);
+        town.SellItemsInCargo(fleet, itemAmount, itemNameSell.text);
         PlayerStateService.AddMoney(price);
         displaySellTab();
         fillInventoryBuyPage();
@@ -379,33 +291,43 @@ public class ShopUI : MonoBehaviour
 
     public void fillInventoryBuyPage()
     {
-        (string[], int[]) inventoryContent = fleet.GetInventory();
+        if (fleet == null)
+        {
+            return;
+        }
+
+        (string[] names, int[] amounts) inventoryContent = fleet.GetInventory();
 
         foreach (Transform contentChild in inventoryScrollViewContent.transform)
         {
             Destroy(contentChild.gameObject);
         }
 
-        for (int i = 0; i < inventoryContent.Item1.Length; i++)
+        for (int i = 0; i < inventoryContent.names.Length; i++)
         {
+            Image icon = Instantiate(inventoryIconPrefab, inventoryScrollViewContent, false);
+            Text inventoryItem = Instantiate(inventoryItemNamePrefab, inventoryScrollViewContent, false);
+            Text inventoryAmount = Instantiate(inventoryNumberPrefab, inventoryScrollViewContent, false);
 
-           
-            
-                Image icon = Instantiate(inventoryIconPrefab);
-                Text inventoryItem = Instantiate(inventoryItemNamePrefab);
-                Text inventoryAmount = Instantiate(inventoryNumberPrefab);
-
-                icon.sprite = inventoryIcons[i];
-                inventoryItem.text = inventoryContent.Item1[i];
-                inventoryAmount.text = inventoryContent.Item2[i].ToString();
-
-                icon.transform.SetParent(inventoryScrollViewContent, false);
-                inventoryItem.transform.SetParent(inventoryScrollViewContent, false);
-                inventoryAmount.transform.SetParent(inventoryScrollViewContent, false);
-            
-
-
+            icon.sprite = inventoryIcons[i];
+            inventoryItem.text = inventoryContent.names[i];
+            inventoryAmount.text = inventoryContent.amounts[i].ToString();
         }
+    }
+
+    private string GetItemDescription(string itemNameToFind)
+    {
+        var tradeInfo = town.SupplyDemandPrice();
+        string[] itemNames = tradeInfo.Item1;
+        for (int i = 0; i < itemNames.Length; i++)
+        {
+            if (itemNames[i].Equals(itemNameToFind))
+            {
+                return town.setupSupplyDescription[i];
+            }
+        }
+
+        return string.Empty;
     }
 
     public void makeBuyButtonDarkBrown()
@@ -425,5 +347,4 @@ public class ShopUI : MonoBehaviour
         buyButton.GetComponent<Image>().color = lightbrown;
         sellButton.GetComponent<Image>().color = darkbrown;
     }
-
 }

--- a/Assets/MapMode/Scripts/UIScripts/TownInfoUI.cs
+++ b/Assets/MapMode/Scripts/UIScripts/TownInfoUI.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections;
-using System.Collections.Generic;
+using System;
 using System.Linq;
 using TMPro;
 using UnityEngine;
@@ -8,76 +6,48 @@ using UnityEngine.UI;
 
 public class TownInfoUI : MonoBehaviour
 {
-    private Town town;
-    private Fleet fleet;
-    private TMP_Text townNameUI;
-    private TMP_Text townDescriptionUI;
-    private Image townImageUI;
+    [Header("Overview References")]
+    [SerializeField] private TMP_Text townNameUI;
+    [SerializeField] private TMP_Text townDescriptionUI;
+    [SerializeField] private Image townImageUI;
 
-    private TMP_Text largestDemandPrice;
-    private TMP_Text largestSupplyPrice;
-    private TMP_Text largestDemandName;
-    private TMP_Text largestSupplyName;
-    private Image largestDemandIcon;
-    private Image largestSupplyIcon;
+    [Header("Supply / Demand References")]
+    [SerializeField] private TMP_Text largestDemandPrice;
+    [SerializeField] private TMP_Text largestSupplyPrice;
+    [SerializeField] private TMP_Text largestDemandName;
+    [SerializeField] private TMP_Text largestSupplyName;
+    [SerializeField] private Image largestDemandIcon;
+    [SerializeField] private Image largestSupplyIcon;
 
-
-
-    private void Start()
+    private void Awake()
     {
-        townNameUI = GameObject.Find("TownName").GetComponent<TMP_Text>();
-        townImageUI = GameObject.Find("TownImage").GetComponent<Image>();
-        townDescriptionUI = GameObject.Find("TownDescription").GetComponent<TMP_Text>();
-        largestDemandPrice = GameObject.Find("HighestDemandPrice").GetComponent<TMP_Text>();
-        largestSupplyPrice = GameObject.Find("HighestSupplyPrice").GetComponent <TMP_Text>();
-        largestSupplyName = GameObject.Find("HighestSupplyName").GetComponent<TMP_Text>();
-        largestDemandName = GameObject.Find("HighestDemandName").GetComponent<TMP_Text>();
-        largestDemandIcon = GameObject.Find("HighestDemandImage").GetComponent<Image>();
-        largestSupplyIcon = GameObject.Find("HighestSupplyImage").GetComponent<Image>();
         gameObject.SetActive(false);
-
     }
-    public void DisplayTownUI(Town t)
+
+    public void DisplayTownUI(Town town)
     {
-        town = t;
+        if (town == null)
+        {
+            return;
+        }
 
-        string townName = t.name;
-        string townDescription = t.townDescription;
-        Sprite townPic = t.townIcon;
+        (string[] itemNames, int[] supply, int[] demand, float[] prices) = town.SupplyDemandPrice();
 
+        int maxDemand = demand.Max();
+        int maxDemandIndex = Array.IndexOf(demand, maxDemand);
+        int maxSupply = supply.Max();
+        int maxSupplyIndex = Array.IndexOf(supply, maxSupply);
 
+        largestDemandName.text = itemNames[maxDemandIndex];
+        largestSupplyName.text = itemNames[maxSupplyIndex];
+        largestDemandIcon.sprite = town.setupSupplyIcons[maxDemandIndex];
+        largestSupplyIcon.sprite = town.setupSupplyIcons[maxSupplyIndex];
+        largestDemandPrice.text = "$" + prices[maxDemandIndex];
+        largestSupplyPrice.text = "$" + prices[maxSupplyIndex];
 
-
-        (string[], int[], int[], float[]) displayInfo = t.SupplyDemandPrice();
-
-        int maxDemand = displayInfo.Item3.Max();
-        int maxDemandIndex = Array.IndexOf(displayInfo.Item3, maxDemand);
-        string maxDemandItem = displayInfo.Item1[maxDemandIndex];
-        largestDemandName.text = maxDemandItem;
-
-        int maxSupply = displayInfo.Item2.Max();
-        int maxSupplyIndex = Array.IndexOf(displayInfo.Item2, maxSupply);
-        string maxSupplyItem = displayInfo.Item1[maxSupplyIndex];
-        largestSupplyName.text = maxSupplyItem;
-
-        for (int i = 0; i < displayInfo.Item1.Length; i++)
-              {
-                  if(displayInfo.Item1[i] == maxDemandItem)
-                  {
-                      largestDemandIcon.sprite = t.setupSupplyIcons[i];
-                      largestDemandPrice.text = "$" + displayInfo.Item4[i].ToString();
-                  }
-
-                  if(displayInfo.Item1[i] == maxSupplyItem)
-                  { 
-                      largestSupplyIcon.sprite = t.setupSupplyIcons[i];
-                      largestSupplyPrice.text = "$" + displayInfo.Item4[i].ToString();
-                  }
-             } 
-
-        townNameUI.text = townName;
-        townDescriptionUI.text = townDescription;
-        townImageUI.sprite = townPic;
+        townNameUI.text = town.name;
+        townDescriptionUI.text = town.townDescription;
+        townImageUI.sprite = town.townIcon;
 
         gameObject.SetActive(true);
     }

--- a/Assets/MapMode/Scripts/UIScripts/TownOptionsUI.cs
+++ b/Assets/MapMode/Scripts/UIScripts/TownOptionsUI.cs
@@ -1,38 +1,28 @@
-﻿using System.Collections;
-using System.Collections.Generic;
 using TMPro;
 using UnityEngine;
 using UnityEngine.UI;
 
 public class TownOptionsUI : MonoBehaviour
 {
-    private Town town;
-    private TMP_Text townNameUI;
-    private TMP_Text townDescriptionUI;
-    private Image townImageUI;
-    private Transform optionsUI;
-    private void Start()
+    [SerializeField] private TMP_Text townNameUI;
+    [SerializeField] private TMP_Text townDescriptionUI;
+    [SerializeField] private Image townImageUI;
+    [SerializeField] private GameObject optionsContainer;
+
+    public void DisplayOptionsMenu(Town town)
     {
-        townNameUI = transform.Find("OptionsContainer/TownNameOP").GetComponent<TMP_Text>();
-        townDescriptionUI = transform.Find("OptionsContainer/TownDescriptionOP").GetComponent<TMP_Text>();
-        townImageUI = transform.Find("OptionsContainer/ImageContainer/TownImageOP").GetComponent<Image>();
-        optionsUI = transform.Find("OptionsContainer");
-    }
-    public void DisplayOptionsMenu(Town t)
-    {
+        if (town == null)
+        {
+            return;
+        }
+
         Time.timeScale = .001f;
 
-        town = t;
-        string townName = t.name;
-        string townDescription = t.townDescription;
-        Sprite townPic = t.townIcon;
+        townNameUI.text = town.name;
+        townDescriptionUI.text = town.townDescription;
+        townImageUI.sprite = town.townIcon;
 
-        townNameUI.text = townName;
-        townDescriptionUI.text = townDescription;
-        townImageUI.sprite = townPic;
-
-        optionsUI.gameObject.SetActive(true);
-
+        optionsContainer.SetActive(true);
     }
 
     public void restartTime()

--- a/Assets/MapMode/Scripts/UIScripts/TownUI.cs
+++ b/Assets/MapMode/Scripts/UIScripts/TownUI.cs
@@ -1,118 +1,114 @@
-﻿using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
-using UnityEngine.SceneManagement;
 using UnityEngine.UI;
 
 public class TownUI : MonoBehaviour
 {
-    private Transform entryContainer;
-    private Transform entryTemplate;
-    private Transform shopUI;
-
-    private Transform quanityContainerBuy;
-    private Transform quanityTemplateBuy;
-
-    private Transform quanityContainerSell;
-    private Transform quanityTemplateSell;
+    [Header("References")]
+    [SerializeField] private Transform entryContainer;
+    [SerializeField] private Transform entryTemplate;
+    [SerializeField] private GameObject shopUI;
+    [SerializeField] private Text townLabel;
+    [SerializeField] private Transform quantityContainerBuy;
+    [SerializeField] private Transform quantityTemplateBuy;
+    [SerializeField] private Transform quantityContainerSell;
+    [SerializeField] private Transform quantityTemplateSell;
 
     private Town town;
     private Fleet fleet;
-    private List<Transform> transformList = new List<Transform>();
-
+    private readonly List<Transform> rowInstances = new List<Transform>();
     private int amount = 50;
-    
 
-    private void Start(){
-        entryContainer = transform.Find("ShopUI/townUiContainer");
-        entryTemplate = entryContainer.transform.Find("ColExample");
+    private void Awake()
+    {
         entryTemplate.gameObject.SetActive(false);
-
-        quanityContainerBuy = transform.Find("QuantityBuy");
-        quanityTemplateBuy = quanityContainerBuy.Find("QuantityEx");
-        quanityContainerSell = transform.Find("QuantitySell");
-        quanityTemplateSell = quanityContainerSell.Find("QuantityEx");
-
-
-        shopUI = transform.Find("ShopUI");
     }
-        
-    
-    public void DisplayTownUI(Town t, Fleet f) {
-        Time.timeScale = .000f;
 
-        string townName = t.name;
-        fleet = f;
-        town = t;
-        (string[], int[], int[], float[]) displayInfo = t.SupplyDemandPrice();
+    public void DisplayTownUI(Town selectedTown, Fleet selectedFleet)
+    {
+        Time.timeScale = 0f;
 
-        shopUI.gameObject.SetActive(true);
+        fleet = selectedFleet;
+        town = selectedTown;
+        (string[] itemNames, int[] supply, int[] demand, float[] prices) = selectedTown.SupplyDemandPrice();
 
-        Transform townText = transform.Find("ShopUI/Town");
-        townText.GetComponent<Text>().text = "Town: " + townName;
+        shopUI.SetActive(true);
+        townLabel.text = "Town: " + selectedTown.name;
 
         float templateHeight = 30f;
-
-        for (int i = 0; i < displayInfo.Item1.Length; i++) {
+        for (int i = 0; i < itemNames.Length; i++)
+        {
             Transform entryTransform = Instantiate(entryTemplate, entryContainer);
-            transformList.Add(entryTransform);
+            rowInstances.Add(entryTransform);
+
             RectTransform entryRectTransform = entryTransform.GetComponent<RectTransform>();
-            entryRectTransform.anchoredPosition = new Vector2(0, -templateHeight * (i+1));
+            entryRectTransform.anchoredPosition = new Vector2(0, -templateHeight * (i + 1));
             entryTransform.gameObject.SetActive(true);
 
-            entryTransform.Find("item").GetComponent<Text>().text = ""+displayInfo.Item1[i];
-            entryTransform.Find("suply").GetComponent<Text>().text = ""+ displayInfo.Item2[i];
-            entryTransform.Find("demand").GetComponent<Text>().text = ""+ displayInfo.Item3[i];
-            entryTransform.Find("price").GetComponent<Text>().text = ""+ displayInfo.Item4[i];
-         
-            string r = displayInfo.Item1[i];
-            entryTransform.Find("buttons/Buy").GetComponent<Button>().onClick.AddListener(delegate { OpenAmountUI(r); });
-            entryTransform.Find("buttons/Sell").GetComponent<Button>().onClick.AddListener(delegate { OpenSellAmountUI(r); });
+            entryTransform.Find("item").GetComponent<Text>().text = itemNames[i];
+            entryTransform.Find("suply").GetComponent<Text>().text = supply[i].ToString();
+            entryTransform.Find("demand").GetComponent<Text>().text = demand[i].ToString();
+            entryTransform.Find("price").GetComponent<Text>().text = prices[i].ToString();
+
+            string resource = itemNames[i];
+            entryTransform.Find("buttons/Buy").GetComponent<Button>().onClick.AddListener(() => OpenAmountUI(resource));
+            entryTransform.Find("buttons/Sell").GetComponent<Button>().onClick.AddListener(() => OpenSellAmountUI(resource));
         }
-    
     }
-    public void CloseTownUI() {
-        foreach (Transform t in transformList) {
-            GameObject.Destroy(t.gameObject);
+
+    public void CloseTownUI()
+    {
+        foreach (Transform row in rowInstances)
+        {
+            Destroy(row.gameObject);
         }
-        transformList = new List<Transform>();
-        shopUI.gameObject.SetActive(false);
-        quanityContainerBuy.gameObject.SetActive(false);
-        quanityContainerSell.gameObject.SetActive(false);
+
+        rowInstances.Clear();
+        shopUI.SetActive(false);
+        quantityContainerBuy.gameObject.SetActive(false);
+        quantityContainerSell.gameObject.SetActive(false);
         Time.timeScale = 1f;
     }
 
-    public void OpenAmountUI(string resource) {
-        quanityContainerBuy.gameObject.SetActive(true);
-        quanityTemplateBuy.Find("Buy").GetComponent<Button>().onClick.RemoveAllListeners();
-        quanityTemplateBuy.Find("Buy").GetComponent<Button>().onClick.AddListener(delegate { BuyItems(resource); });
+    public void OpenAmountUI(string resource)
+    {
+        quantityContainerBuy.gameObject.SetActive(true);
+        Button buyButton = quantityTemplateBuy.Find("Buy").GetComponent<Button>();
+        buyButton.onClick.RemoveAllListeners();
+        buyButton.onClick.AddListener(() => BuyItems(resource));
+
         amount = 50;
-        quanityTemplateBuy.Find("Amount").GetComponent<Text>().text = "" + amount;
+        quantityTemplateBuy.Find("Amount").GetComponent<Text>().text = amount.ToString();
     }
 
-    public void BuyItems(string resource) {
-        town.FillCargoPlayer(fleet,resource,amount);
+    public void BuyItems(string resource)
+    {
+        town.FillCargoPlayer(fleet, resource, amount);
         CloseTownUI();
-        DisplayTownUI(town,fleet);
-        
+        DisplayTownUI(town, fleet);
     }
 
-    public void ChangeCount(int a) {
-        amount += a;
-        quanityTemplateBuy.Find("Amount").GetComponent<Text>().text = ""+amount;
-        quanityTemplateSell.Find("Amount").GetComponent<Text>().text = "" + amount;
+    public void ChangeCount(int change)
+    {
+        amount += change;
+        quantityTemplateBuy.Find("Amount").GetComponent<Text>().text = amount.ToString();
+        quantityTemplateSell.Find("Amount").GetComponent<Text>().text = amount.ToString();
     }
-    public void OpenSellAmountUI(string resource) {
-        quanityContainerSell.gameObject.SetActive(true);
-        quanityTemplateSell.transform.Find("Sell").GetComponent<Button>().onClick.RemoveAllListeners();
-        quanityTemplateSell.transform.Find("Sell").GetComponent<Button>().onClick.AddListener(delegate { SellItem(resource); });
+
+    public void OpenSellAmountUI(string resource)
+    {
+        quantityContainerSell.gameObject.SetActive(true);
+        Button sellButton = quantityTemplateSell.Find("Sell").GetComponent<Button>();
+        sellButton.onClick.RemoveAllListeners();
+        sellButton.onClick.AddListener(() => SellItem(resource));
+
         amount = 50;
-        quanityTemplateSell.transform.Find("Amount").GetComponent<Text>().text = "" + amount;
-
+        quantityTemplateSell.Find("Amount").GetComponent<Text>().text = amount.ToString();
     }
 
-    public void SellItem(string resource) {//player sell item
-        town.SellItemsInCargo(fleet,amount,resource);
+    public void SellItem(string resource)
+    {
+        town.SellItemsInCargo(fleet, amount, resource);
         CloseTownUI();
         DisplayTownUI(town, fleet);
     }
@@ -120,10 +116,5 @@ public class TownUI : MonoBehaviour
     public void LoadSceneBoatShop()
     {
         SceneTransfer.TransferToTownUI();
-        
-        
     }
-
-    
-
 }

--- a/Assets/MapMode/Scripts/UIScripts/TownUIContext.cs
+++ b/Assets/MapMode/Scripts/UIScripts/TownUIContext.cs
@@ -1,0 +1,17 @@
+using System;
+using UnityEngine;
+
+public class TownUIContext : MonoBehaviour
+{
+    public Town CurrentTown { get; private set; }
+    public Fleet CurrentFleet { get; private set; }
+
+    public event Action<Town, Fleet> ContextChanged;
+
+    public void SetContext(Town town, Fleet fleet)
+    {
+        CurrentTown = town;
+        CurrentFleet = fleet;
+        ContextChanged?.Invoke(CurrentTown, CurrentFleet);
+    }
+}

--- a/Assets/MapMode/Scripts/UIScripts/TownUIContext.cs.meta
+++ b/Assets/MapMode/Scripts/UIScripts/TownUIContext.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5bad909f6c1599244b959ac1dbfb6b91
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/IslandView.unity
+++ b/Assets/Scenes/IslandView.unity
@@ -799,6 +799,11 @@ PrefabInstance:
       objectReference: {fileID: 1252930511}
     - target: {fileID: 2356750811951124822, guid: ed590d6da9fa7df4a93fabd75a23e647,
         type: 3}
+      propertyPath: townUI
+      value: 
+      objectReference: {fileID: 197484706}
+    - target: {fileID: 2356750811951124822, guid: ed590d6da9fa7df4a93fabd75a23e647,
+        type: 3}
       propertyPath: townIcon
       value: 
       objectReference: {fileID: 21300000, guid: fbd62b85b632cc541ad78d0a775f955f,
@@ -1868,6 +1873,11 @@ PrefabInstance:
       objectReference: {fileID: 1252930511}
     - target: {fileID: 2356750811951124822, guid: ed590d6da9fa7df4a93fabd75a23e647,
         type: 3}
+      propertyPath: townUI
+      value: 
+      objectReference: {fileID: 197484706}
+    - target: {fileID: 2356750811951124822, guid: ed590d6da9fa7df4a93fabd75a23e647,
+        type: 3}
       propertyPath: m_Enabled
       value: 1
       objectReference: {fileID: 0}
@@ -2365,6 +2375,15 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 29031ddcdbbb20540814d0fce0b8be4c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  townNameUI: {fileID: 0}
+  townDescriptionUI: {fileID: 0}
+  townImageUI: {fileID: 0}
+  largestDemandPrice: {fileID: 0}
+  largestSupplyPrice: {fileID: 0}
+  largestDemandName: {fileID: 0}
+  largestSupplyName: {fileID: 0}
+  largestDemandIcon: {fileID: 0}
+  largestSupplyIcon: {fileID: 0}
 --- !u!1 &202119736
 GameObject:
   m_ObjectHideFlags: 0
@@ -6745,6 +6764,11 @@ PrefabInstance:
       objectReference: {fileID: 1252930511}
     - target: {fileID: 2356750811951124822, guid: ed590d6da9fa7df4a93fabd75a23e647,
         type: 3}
+      propertyPath: townUI
+      value: 
+      objectReference: {fileID: 197484706}
+    - target: {fileID: 2356750811951124822, guid: ed590d6da9fa7df4a93fabd75a23e647,
+        type: 3}
       propertyPath: townIcon
       value: 
       objectReference: {fileID: 21300000, guid: fbd62b85b632cc541ad78d0a775f955f,
@@ -7791,6 +7815,11 @@ PrefabInstance:
       objectReference: {fileID: 1252930511}
     - target: {fileID: 2356750811951124822, guid: ed590d6da9fa7df4a93fabd75a23e647,
         type: 3}
+      propertyPath: townUI
+      value: 
+      objectReference: {fileID: 197484706}
+    - target: {fileID: 2356750811951124822, guid: ed590d6da9fa7df4a93fabd75a23e647,
+        type: 3}
       propertyPath: townIcon
       value: 
       objectReference: {fileID: 21300000, guid: fbd62b85b632cc541ad78d0a775f955f,
@@ -8815,6 +8844,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 03aab51fe73af824f862bb88389f5705, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  townUIContext: {fileID: 908102731}
   scrollViewContent: {fileID: 883984829}
   buyInfoPanel: {fileID: 8899877140558855287, guid: f4904b7147b7fd847afc4234527d9d2e,
     type: 3}
@@ -8867,6 +8897,11 @@ PrefabInstance:
       propertyPath: parent
       value: 
       objectReference: {fileID: 1252930511}
+    - target: {fileID: 2356750811951124822, guid: ed590d6da9fa7df4a93fabd75a23e647,
+        type: 3}
+      propertyPath: townUI
+      value: 
+      objectReference: {fileID: 197484706}
     - target: {fileID: 2356750811951124822, guid: ed590d6da9fa7df4a93fabd75a23e647,
         type: 3}
       propertyPath: m_Enabled
@@ -10326,6 +10361,7 @@ GameObject:
   - component: {fileID: 908102727}
   - component: {fileID: 908102729}
   - component: {fileID: 908102730}
+  - component: {fileID: 908102731}
   m_Layer: 5
   m_Name: TownOptions
   m_TagString: Untagged
@@ -10371,6 +10407,22 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 7def2a4216fd6d142ba229ea126391a8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  townNameUI: {fileID: 712269537}
+  townDescriptionUI: {fileID: 0}
+  townImageUI: {fileID: 0}
+  optionsContainer: {fileID: 0}
+--- !u!114 &908102731
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 908102726}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5bad909f6c1599244b959ac1dbfb6b91, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1 &913128102
@@ -10762,6 +10814,11 @@ PrefabInstance:
       propertyPath: parent
       value: 
       objectReference: {fileID: 1252930511}
+    - target: {fileID: 2356750811951124822, guid: ed590d6da9fa7df4a93fabd75a23e647,
+        type: 3}
+      propertyPath: townUI
+      value: 
+      objectReference: {fileID: 197484706}
     - target: {fileID: 2356750811951124822, guid: ed590d6da9fa7df4a93fabd75a23e647,
         type: 3}
       propertyPath: m_Enabled
@@ -13861,6 +13918,11 @@ PrefabInstance:
       objectReference: {fileID: 1252930511}
     - target: {fileID: 2356750811951124822, guid: ed590d6da9fa7df4a93fabd75a23e647,
         type: 3}
+      propertyPath: townUI
+      value: 
+      objectReference: {fileID: 197484706}
+    - target: {fileID: 2356750811951124822, guid: ed590d6da9fa7df4a93fabd75a23e647,
+        type: 3}
       propertyPath: m_Enabled
       value: 1
       objectReference: {fileID: 0}
@@ -16028,6 +16090,11 @@ PrefabInstance:
       objectReference: {fileID: 1252930511}
     - target: {fileID: 2356750811951124822, guid: ed590d6da9fa7df4a93fabd75a23e647,
         type: 3}
+      propertyPath: townUI
+      value: 
+      objectReference: {fileID: 197484706}
+    - target: {fileID: 2356750811951124822, guid: ed590d6da9fa7df4a93fabd75a23e647,
+        type: 3}
       propertyPath: m_Enabled
       value: 1
       objectReference: {fileID: 0}
@@ -17897,7 +17964,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2266d5c0b5573ca43a9e749593d91299, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Canvas: {fileID: 481727670}
+  meetShipUI: {fileID: 1037125098}
+  townOptionsUI: {fileID: 908102730}
+  townUIContext: {fileID: 908102731}
   navAgent: {fileID: 1439832478}
   target: {fileID: 753358948}
   _boatNames: 
@@ -17959,6 +18028,11 @@ PrefabInstance:
       propertyPath: parent
       value: 
       objectReference: {fileID: 1252930511}
+    - target: {fileID: 2356750811951124822, guid: ed590d6da9fa7df4a93fabd75a23e647,
+        type: 3}
+      propertyPath: townUI
+      value: 
+      objectReference: {fileID: 197484706}
     - target: {fileID: 2356750811951124822, guid: ed590d6da9fa7df4a93fabd75a23e647,
         type: 3}
       propertyPath: m_Enabled
@@ -20076,6 +20150,11 @@ PrefabInstance:
       propertyPath: parent
       value: 
       objectReference: {fileID: 1252930511}
+    - target: {fileID: 2356750811951124822, guid: ed590d6da9fa7df4a93fabd75a23e647,
+        type: 3}
+      propertyPath: townUI
+      value: 
+      objectReference: {fileID: 197484706}
     - target: {fileID: 2356750811951124822, guid: ed590d6da9fa7df4a93fabd75a23e647,
         type: 3}
       propertyPath: m_Enabled
@@ -23080,6 +23159,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 88c5ab0b9adebbe40a00c5c6f27206c6, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  entryContainer: {fileID: 0}
+  entryTemplate: {fileID: 0}
+  shopUI: {fileID: 0}
+  townLabel: {fileID: 0}
+  quantityContainerBuy: {fileID: 0}
+  quantityTemplateBuy: {fileID: 0}
+  quantityContainerSell: {fileID: 0}
+  quantityTemplateSell: {fileID: 0}
 --- !u!1 &1982377350
 GameObject:
   m_ObjectHideFlags: 0
@@ -23138,6 +23225,15 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   baseCostPerShip: 200
   costPerUnitDistance: 1
+  enablePirateSpawns: 1
+  enableNavalPatrolSpawns: 1
+  enableWarFleetSpawns: 0
+  pirateSpawnInterval: 45
+  navalPatrolSpawnInterval: 60
+  warFleetSpawnInterval: 90
+  pirateFleetSize: 2
+  patrolFleetSize: 2
+  warFleetSize: 3
 --- !u!1 &1984374136
 GameObject:
   m_ObjectHideFlags: 0
@@ -23722,6 +23818,11 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 1982377351}
     m_Modifications:
+    - target: {fileID: 2356750811951124822, guid: ed590d6da9fa7df4a93fabd75a23e647,
+        type: 3}
+      propertyPath: townUI
+      value: 
+      objectReference: {fileID: 197484706}
     - target: {fileID: 2356750811951124822, guid: ed590d6da9fa7df4a93fabd75a23e647,
         type: 3}
       propertyPath: nationality
@@ -25630,6 +25731,11 @@ PrefabInstance:
       propertyPath: parent
       value: 
       objectReference: {fileID: 1252930511}
+    - target: {fileID: 2356750811951124822, guid: ed590d6da9fa7df4a93fabd75a23e647,
+        type: 3}
+      propertyPath: townUI
+      value: 
+      objectReference: {fileID: 197484706}
     - target: {fileID: 2356750811951124822, guid: ed590d6da9fa7df4a93fabd75a23e647,
         type: 3}
       propertyPath: townIcon

--- a/Assets/Scenes/IslandView.unity
+++ b/Assets/Scenes/IslandView.unity
@@ -2375,15 +2375,15 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 29031ddcdbbb20540814d0fce0b8be4c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  townNameUI: {fileID: 0}
-  townDescriptionUI: {fileID: 0}
-  townImageUI: {fileID: 0}
-  largestDemandPrice: {fileID: 0}
-  largestSupplyPrice: {fileID: 0}
-  largestDemandName: {fileID: 0}
-  largestSupplyName: {fileID: 0}
-  largestDemandIcon: {fileID: 0}
-  largestSupplyIcon: {fileID: 0}
+  townNameUI: {fileID: 441275095}
+  townDescriptionUI: {fileID: 653283905}
+  townImageUI: {fileID: 1090357110}
+  largestDemandPrice: {fileID: 1640565238}
+  largestSupplyPrice: {fileID: 1449210073}
+  largestDemandName: {fileID: 1706439842}
+  largestSupplyName: {fileID: 1333568807}
+  largestDemandIcon: {fileID: 1592541054}
+  largestSupplyIcon: {fileID: 484784856}
 --- !u!1 &202119736
 GameObject:
   m_ObjectHideFlags: 0
@@ -10410,9 +10410,9 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   townNameUI: {fileID: 712269537}
-  townDescriptionUI: {fileID: 0}
-  townImageUI: {fileID: 0}
-  optionsContainer: {fileID: 0}
+  townDescriptionUI: {fileID: 712269537}
+  townImageUI: {fileID: 2134784385}
+  optionsContainer: {fileID: 202119736}
 --- !u!114 &908102731
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -87,7 +87,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.render-pipelines.core": {
-      "version": "14.0.11",
+      "version": "14.0.12",
       "depth": 1,
       "source": "builtin",
       "dependencies": {
@@ -109,7 +109,7 @@
       "depth": 0,
       "source": "builtin",
       "dependencies": {
-        "com.unity.render-pipelines.core": "14.0.11",
+        "com.unity.render-pipelines.core": "14.0.12",
         "com.unity.searcher": "4.9.2"
       }
     },

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2022.3.49f1
-m_EditorVersionWithRevision: 2022.3.49f1 (4dae1bb8668d)
+m_EditorVersion: 2022.3.62f3
+m_EditorVersionWithRevision: 2022.3.62f3 (96770f904ca7)


### PR DESCRIPTION
### Motivation
- Remove brittle `GameObject.Find(...)` and static UI coupling so town UIs are robust and editor-friendly.
- Keep the runtime design simple for single-player while making it straightforward to extend to player-specific contexts later.
- Keep UI logic focused on presentation and input wiring rather than owning game state or global lookups.

### Description
- Add `TownUIContext` (component) that holds the active `Town` + `Fleet` and broadcasts changes via `ContextChanged`, and wire it from `PlayerFleetMapController` at town entry using `SetContext` instead of a static `currentTown`.
- Refactor `ShopUI` to accept a `TownUIContext` reference, subscribe/unsubscribe to context updates, and read `Town`/`Fleet` from the context while centralizing list population into `PopulateTradeList` and replacing the long item-description `if/else` with `GetItemDescription`.
- Convert `TownInfoUI`, `TownOptionsUI`, and `TownUI` to inspector-driven references (serialized fields) and null-safe usage so they no longer rely on hierarchy name lookups or `GameObject.Find`.
- Update `Town` to expose a serialized `TownInfoUI` reference, guard hover calls with null checks, and use `this` when requesting items from `TownManager`.

### Testing
- Ran `git diff --check` to validate there are no obvious whitespace/diff-check issues, and it passed. 
- Ran targeted grep checks (`rg -n "PlayerFleetMapController\.currentTown|GameObject.Find\("`) to confirm removal of static/lookup usage where expected, and they returned expected results (no lingering problematic usages in modified town UI flow).
- Verified a commit was created containing the changes (`Refactor town UI to inspector-wired context architecture`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b7677a39308333886f97092b75f761)