### PR TITLE
Introduce CannonStationSpawner and centralize cannon spawning; update player cannon trigger handling

### DIFF
--- a/Assets/Combat/Scripts/BoatScripts/BoatAIOld/BoatTeamManager.cs
+++ b/Assets/Combat/Scripts/BoatScripts/BoatAIOld/BoatTeamManager.cs
@@ -61,11 +61,7 @@ public class BoatTeamManager : MonoBehaviour
             numberOfSailors += 1;
         }
         
-        CannonInterface[] cannons = spawnedBoat.GetComponentsInChildren<CannonInterface>();
-        foreach (var cannon in cannons)
-        {
-            cannon.SetCannonValues(b.cannon ?? new Cannon(CannonType.LongGun));
-        }
+        ConfigureBoatCannons(spawnedBoat, b.cannon);
     }
     public void SpawnPlayerBoat(Boat b)
     {
@@ -97,11 +93,7 @@ public class BoatTeamManager : MonoBehaviour
         }
 
         
-        CannonInterface[] cannons = spawnedBoat.GetComponentsInChildren<CannonInterface>();
-        foreach (var cannon in cannons)
-        {
-            cannon.SetCannonValues(b.cannon ?? new Cannon(CannonType.LongGun));
-        }
+        ConfigureBoatCannons(spawnedBoat, b.cannon);
 
         Transform playerAI = boatAiTransform.Find("ECM_BaseFirstPersonControllerAI"); 
         playerAI.parent = spawnedAIBoat.transform;
@@ -115,6 +107,33 @@ public class BoatTeamManager : MonoBehaviour
         cameraTopDown.GetComponent<TopDownCamController>().SetUPCamera(spawnedBoat.transform);
         var camControl  = GameObject.Find("CameraWrapper").GetComponent<FollowCameraController>();
         camControl.SetUPCamera(spawnedBoat);
+    }
+
+
+    private static void ConfigureBoatCannons(GameObject spawnedBoat, Cannon cannonConfig)
+    {
+        if (cannonConfig == null)
+        {
+            Debug.LogError($"{spawnedBoat.name} does not have a cannon config. Migration requires Boat.cannon to be set.");
+            return;
+        }
+
+        CannonStationSpawner[] cannonStations = spawnedBoat.GetComponentsInChildren<CannonStationSpawner>(true);
+
+        if (cannonStations.Length == 0)
+        {
+            Debug.LogError($"{spawnedBoat.name} has no {nameof(CannonStationSpawner)} components. Add cannon stations to the boat prefab.");
+            return;
+        }
+
+        foreach (var station in cannonStations)
+        {
+            CannonInterface spawnedCannon = station.SpawnCannon(cannonConfig);
+            if (spawnedCannon == null)
+            {
+                Debug.LogError($"{spawnedBoat.name} has a cannon station that failed to spawn a cannon. Check station prefab references.");
+            }
+        }
     }
 
     public int GetTeam() {

--- a/Assets/Combat/Scripts/PlayerScripts/PlayerTriggerController.cs
+++ b/Assets/Combat/Scripts/PlayerScripts/PlayerTriggerController.cs
@@ -129,7 +129,18 @@ public class PlayerTriggerController : MonoBehaviour
         //Debug.Log("Entered Trigger of " + other.transform.name);
         if (other.CompareTag("Cannon")) {
             hud.cannonKeyOn();
-            activeCannon = other.gameObject.GetComponent<CannonInterface>();
+
+            CannonStationSpawner cannonStation = other.GetComponent<CannonStationSpawner>()
+                ?? other.GetComponentInParent<CannonStationSpawner>();
+
+            if (cannonStation != null)
+            {
+                activeCannon = cannonStation.SpawnedCannon;
+            }
+            else
+            {
+                Debug.LogWarning($"{other.name} is tagged Cannon but has no {nameof(CannonStationSpawner)} in its hierarchy.");
+            }
         }
         if (other.CompareTag("steeringWheel")) {
             triggerInsideOf = other;

--- a/Assets/Combat/Scripts/ShootingScripts/CannonStationSpawner.cs
+++ b/Assets/Combat/Scripts/ShootingScripts/CannonStationSpawner.cs
@@ -1,0 +1,80 @@
+using MapMode.Scripts.DataTypes.boatComponents.Cannons;
+using UnityEngine;
+
+public class CannonStationSpawner : MonoBehaviour
+{
+    [Header("Spawn Setup")]
+    [SerializeField] private GameObject cannonPrefab;
+    [SerializeField] private Transform cannonSpawnPoint;
+    [SerializeField] private Transform spawnedCannonParent;
+    [Header("Control Trigger")]
+    [SerializeField] private Collider controlTrigger;
+    [SerializeField] private int cannonSetNumber;
+
+    private CannonInterface spawnedCannon;
+
+    public CannonInterface SpawnedCannon => spawnedCannon;
+
+    private void Start()
+    {
+        EnsureTriggerIsConfigured();
+    }
+
+    public CannonInterface SpawnCannon(Cannon cannonConfig)
+    {
+        if (cannonConfig == null)
+        {
+            Debug.LogError($"{name}: Cannon config is null. Boat must provide a cannon configuration during spawn.");
+            return null;
+        }
+
+        if (cannonPrefab == null)
+        {
+            Debug.LogWarning($"{name}: Cannon prefab is not set on {nameof(CannonStationSpawner)}.");
+            return null;
+        }
+
+        if (spawnedCannon != null)
+        {
+            Destroy(spawnedCannon.gameObject);
+            spawnedCannon = null;
+        }
+
+        var spawnPoint = cannonSpawnPoint != null ? cannonSpawnPoint : transform;
+        var parent = spawnedCannonParent != null ? spawnedCannonParent : transform;
+
+        GameObject spawnedObject = Instantiate(cannonPrefab, spawnPoint.position, spawnPoint.rotation, parent);
+        spawnedObject.name = $"{cannonPrefab.name}_Spawned";
+
+        spawnedCannon = spawnedObject.GetComponent<CannonInterface>();
+        if (spawnedCannon == null)
+        {
+            Debug.LogError($"{name}: Spawned cannon prefab does not contain a {nameof(CannonInterface)} component.");
+            return null;
+        }
+
+        spawnedCannon.setCannonSetNum(cannonSetNumber);
+        spawnedCannon.SetCannonValues(cannonConfig);
+
+        return spawnedCannon;
+    }
+
+    private void EnsureTriggerIsConfigured()
+    {
+        if (controlTrigger == null)
+        {
+            controlTrigger = GetComponent<Collider>();
+        }
+
+        if (controlTrigger == null)
+        {
+            return;
+        }
+
+        controlTrigger.isTrigger = true;
+        if (!controlTrigger.CompareTag("Cannon"))
+        {
+            controlTrigger.tag = "Cannon";
+        }
+    }
+}

--- a/Assets/Combat/Scripts/ShootingScripts/CannonStationSpawner.cs.meta
+++ b/Assets/Combat/Scripts/ShootingScripts/CannonStationSpawner.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b83b3c4f7db54caa940986545ad1be9d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
### Motivation

- Consolidate cannon spawning logic into a reusable spawner to support migrated boat prefabs and ensure consistent cannon initialization.
- Make player interaction with cannons robust when cannons are spawned dynamically by stations rather than present as direct child components.

### Description

- Add `CannonStationSpawner` (`Assets/Combat/Scripts/ShootingScripts/CannonStationSpawner.cs`) which encapsulates cannon prefab spawning, configuration, trigger tagging, and returns the spawned `CannonInterface` via `SpawnCannon` and the `SpawnedCannon` property.
- Replace direct per-boat `CannonInterface` enumeration in `BoatTeamManager` with a new helper `ConfigureBoatCannons(GameObject, Cannon)` that finds `CannonStationSpawner` components (including inactive children), validates `Boat.cannon`, and instructs each station to spawn and initialize its cannon.
- Update `PlayerTriggerController.OnTriggerEnter` to resolve the active cannon by finding a `CannonStationSpawner` on the collider or in its parent and using the station's `SpawnedCannon`, and emit a warning when a collider tagged `Cannon` has no station.
- Add the meta file for the new `CannonStationSpawner` script.

### Testing

- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c57b0b484083339e16f1a03d550ad1)