### PR TITLE
Initialize BoatAI action to 'FireAtWill' and remove unused using

### DIFF
--- a/Assets/Combat/Scripts/BoatScripts/BoatAINew/BoatAI.cs
+++ b/Assets/Combat/Scripts/BoatScripts/BoatAINew/BoatAI.cs
@@ -1,5 +1,4 @@
 ﻿
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using MapMode.Scripts.DataTypes.boatComponents.Cannons;
@@ -54,7 +53,7 @@ public class BoatAI : MonoBehaviour
 
     private PandaBehaviour pandaBT = null;
     [Task]
-    public string action;
+    public string action = "FireAtWill";
     
     private bool _isDead = false;
     [Task]


### PR DESCRIPTION
### Motivation
- Ensure the AI has a safe default behavior by initializing the `action` field to `FireAtWill` and remove the unused `using System;` to clean up warnings.

### Description
- Set `public string action = "FireAtWill";` in `BoatAI.cs` and removed the unused `using System;` directive; no other behavior changes.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c5f4734f9483338ca51b0c0668cf66)