### PR TITLE
Refactor fleet AI decisions into per-type policy classes

### DIFF
--- a/Assets/MapMode/Scripts/FleetAIPolicy.cs
+++ b/Assets/MapMode/Scripts/FleetAIPolicy.cs
@@ -1,0 +1,181 @@
+public interface IFleetAIPolicy
+{
+    FleetAIState GetInitialState(FleetMapController controller);
+    bool CanEngage(FleetMapController controller, Fleet otherFleet);
+    void Tick(FleetMapController controller);
+    void UpdateAfterEncounter(FleetMapController controller, FleetMapController otherFleetController, bool wonBattle);
+}
+
+public static class FleetAIPolicyFactory
+{
+    public static IFleetAIPolicy CreateFor(AIFleetType fleetType)
+    {
+        switch (fleetType)
+        {
+            case AIFleetType.Trade:
+                return new TradeFleetAIPolicy();
+            case AIFleetType.Pirate:
+                return new PirateFleetAIPolicy();
+            case AIFleetType.NavalPatrol:
+                return new NavalPatrolFleetAIPolicy();
+            case AIFleetType.War:
+                return new WarFleetAIPolicy();
+            default:
+                return new DefaultFleetAIPolicy();
+        }
+    }
+}
+
+public class DefaultFleetAIPolicy : IFleetAIPolicy
+{
+    public virtual FleetAIState GetInitialState(FleetMapController controller) => FleetAIState.Idle;
+    public virtual bool CanEngage(FleetMapController controller, Fleet otherFleet) => false;
+    public virtual void Tick(FleetMapController controller) { }
+    public virtual void UpdateAfterEncounter(FleetMapController controller, FleetMapController otherFleetController, bool wonBattle)
+    {
+        controller.ClearCurrentTarget();
+        controller.ChangeState(FleetAIState.Idle);
+    }
+}
+
+public class TradeFleetAIPolicy : DefaultFleetAIPolicy
+{
+    public override FleetAIState GetInitialState(FleetMapController controller) => FleetAIState.TransitToTown;
+
+    public override bool CanEngage(FleetMapController controller, Fleet otherFleet)
+    {
+        return otherFleet != null && otherFleet.FleetType == AIFleetType.Pirate;
+    }
+
+    public override void Tick(FleetMapController controller)
+    {
+        if (controller.CurrentState == FleetAIState.TransitToTown)
+        {
+            FleetMapController threat = controller.FindNearestHostileFleet();
+            if (threat != null && controller.ShouldFleeFrom(threat))
+            {
+                controller.SetCurrentTarget(threat);
+                controller.ChangeState(FleetAIState.Flee);
+            }
+            return;
+        }
+
+        if (controller.CurrentState == FleetAIState.Flee || controller.CurrentState == FleetAIState.Regroup)
+        {
+            controller.SetDestinationToNearestFriendlyTown();
+        }
+    }
+
+    public override void UpdateAfterEncounter(FleetMapController controller, FleetMapController otherFleetController, bool wonBattle)
+    {
+        controller.ClearCurrentTarget();
+        if (!wonBattle)
+        {
+            controller.ChangeState(FleetAIState.Flee);
+            return;
+        }
+
+        controller.ChangeState(FleetAIState.TransitToTown);
+    }
+}
+
+public class PirateFleetAIPolicy : DefaultFleetAIPolicy
+{
+    public override FleetAIState GetInitialState(FleetMapController controller) => FleetAIState.Search;
+
+    public override bool CanEngage(FleetMapController controller, Fleet otherFleet)
+    {
+        return otherFleet != null &&
+               (otherFleet.FleetType == AIFleetType.Trade ||
+                otherFleet.FleetType == AIFleetType.NavalPatrol ||
+                otherFleet.FleetType == AIFleetType.War);
+    }
+
+    public override void Tick(FleetMapController controller)
+    {
+        HandleSearchAndIntercept(controller);
+    }
+
+    public override void UpdateAfterEncounter(FleetMapController controller, FleetMapController otherFleetController, bool wonBattle)
+    {
+        controller.ClearCurrentTarget();
+        FleetMapController newTarget = controller.FindNearestHostileFleet();
+        if (newTarget != null)
+        {
+            controller.SetCurrentTarget(newTarget);
+            controller.ChangeState(FleetAIState.InterceptTarget);
+            return;
+        }
+
+        controller.ChangeState(FleetAIState.Search);
+    }
+
+    protected void HandleSearchAndIntercept(FleetMapController controller)
+    {
+        if (controller.CurrentState == FleetAIState.Search || controller.CurrentState == FleetAIState.PatrolRoute)
+        {
+            FleetMapController target = controller.FindNearestHostileFleet();
+            if (target != null)
+            {
+                controller.SetCurrentTarget(target);
+                controller.ChangeState(FleetAIState.InterceptTarget);
+            }
+
+            return;
+        }
+
+        if (controller.CurrentState == FleetAIState.InterceptTarget)
+        {
+            if (!controller.HasValidCurrentTarget())
+            {
+                controller.ClearCurrentTarget();
+                controller.ChangeState(FleetAIState.Search);
+                return;
+            }
+
+            controller.SyncDestinationToCurrentTarget();
+
+            if (controller.GetFleetHealthRatio() < controller.RegroupHpThreshold)
+            {
+                controller.ChangeState(FleetAIState.Regroup);
+            }
+
+            return;
+        }
+
+        if (controller.CurrentState == FleetAIState.Regroup || controller.CurrentState == FleetAIState.Flee)
+        {
+            controller.SetDestinationToNearestFriendlyTown();
+        }
+    }
+}
+
+public class NavalPatrolFleetAIPolicy : PirateFleetAIPolicy
+{
+    public override FleetAIState GetInitialState(FleetMapController controller) => FleetAIState.PatrolRoute;
+
+    public override bool CanEngage(FleetMapController controller, Fleet otherFleet)
+    {
+        return otherFleet != null && otherFleet.FleetType == AIFleetType.Pirate;
+    }
+}
+
+public class WarFleetAIPolicy : PirateFleetAIPolicy
+{
+    public override FleetAIState GetInitialState(FleetMapController controller) => FleetAIState.PatrolRoute;
+
+    public override bool CanEngage(FleetMapController controller, Fleet otherFleet)
+    {
+        if (otherFleet == null || controller.GetFleet() == null)
+        {
+            return false;
+        }
+
+        if (otherFleet.FleetType == AIFleetType.Pirate)
+        {
+            return true;
+        }
+
+        return otherFleet.FleetType == AIFleetType.War && otherFleet.Nationality != controller.GetFleet().Nationality;
+    }
+}

--- a/Assets/MapMode/Scripts/FleetAIPolicy.cs.meta
+++ b/Assets/MapMode/Scripts/FleetAIPolicy.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7f2d54a9f3d14e4f8b5a38d39e945d5a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MapMode/Scripts/FleetMapController.cs
+++ b/Assets/MapMode/Scripts/FleetMapController.cs
@@ -4,7 +4,6 @@ using System.Collections.Generic;
 using MapMode.Scripts;
 using UnityEngine;
 using UnityEngine.AI;
-using static UnityEngine.GraphicsBuffer;
 
 public class FleetMapController : MonoBehaviour
 {
@@ -31,6 +30,7 @@ public class FleetMapController : MonoBehaviour
     [SerializeField] private float fleePowerRatioThreshold = 1.1f;
     [SerializeField] private float regroupHpThreshold = 0.35f;
     private float aiTickTimer = 0f;
+    private IFleetAIPolicy aiPolicy = new DefaultFleetAIPolicy();
 
 
     Fleet fleet;
@@ -161,33 +161,7 @@ public class FleetMapController : MonoBehaviour
             return;
         }
 
-        CurrentTarget = null;
-
-        if (CurrentState == FleetAIState.Flee && wonBattle)
-        {
-            ChangeState(FleetAIState.Regroup);
-            return;
-        }
-
-        if (fleet.FleetType == AIFleetType.Pirate || fleet.FleetType == AIFleetType.NavalPatrol || fleet.FleetType == AIFleetType.War)
-        {
-            FleetMapController newTarget = FindNearestHostileFleet();
-            if (newTarget != null)
-            {
-                CurrentTarget = newTarget;
-                destination = newTarget.transform;
-                ChangeState(FleetAIState.InterceptTarget);
-                return;
-            }
-        }
-
-        if (fleet.FleetType == AIFleetType.Trade && !wonBattle)
-        {
-            ChangeState(FleetAIState.Flee);
-            return;
-        }
-
-        ChangeState(FleetAIState.Search);
+        aiPolicy.UpdateAfterEncounter(this, otherFleetController, wonBattle);
     }
 
     private FleetMapController FindClosestFleet(System.Func<Fleet, bool> predicate)
@@ -244,6 +218,7 @@ public class FleetMapController : MonoBehaviour
     public void SetFleet(Fleet f) {fleet = f;}
     public Fleet GetFleet(){ return fleet;}
     public void ChangeState(FleetAIState newState) { CurrentState = newState; }
+    public float RegroupHpThreshold => regroupHpThreshold;
 
     public void DockFleet(Town town) {
         town.DockFleet(fleet);
@@ -301,23 +276,8 @@ public class FleetMapController : MonoBehaviour
     private void InitializeAIState()
     {
         CurrentTarget = null;
-
-        switch (fleet.FleetType)
-        {
-            case AIFleetType.Trade:
-                ChangeState(FleetAIState.TransitToTown);
-                break;
-            case AIFleetType.Pirate:
-                ChangeState(FleetAIState.Search);
-                break;
-            case AIFleetType.NavalPatrol:
-            case AIFleetType.War:
-                ChangeState(FleetAIState.PatrolRoute);
-                break;
-            default:
-                ChangeState(FleetAIState.Idle);
-                break;
-        }
+        aiPolicy = FleetAIPolicyFactory.CreateFor(fleet.FleetType);
+        ChangeState(aiPolicy.GetInitialState(this));
     }
 
     private void TickAI()
@@ -335,78 +295,49 @@ public class FleetMapController : MonoBehaviour
             return;
         }
 
-        switch (CurrentState)
-        {
-            case FleetAIState.TransitToTown:
-                TickTransit();
-                break;
-            case FleetAIState.PatrolRoute:
-            case FleetAIState.Search:
-                TickSearch();
-                break;
-            case FleetAIState.InterceptTarget:
-                TickIntercept();
-                break;
-            case FleetAIState.Flee:
-                TickFlee();
-                break;
-            case FleetAIState.Regroup:
-                TickRegroup();
-                break;
-        }
+        aiPolicy.Tick(this);
     }
 
-    private void TickTransit()
+    public void SetCurrentTarget(FleetMapController target)
     {
-        if (fleet.FleetType != AIFleetType.Trade)
-        {
-            return;
-        }
-
-        FleetMapController threat = FindNearestHostileFleet();
-        if (threat != null)
-        {
-            float selfPower = BattlePredicter.GetFleetPower(fleet);
-            float threatPower = BattlePredicter.GetFleetPower(threat.GetFleet());
-            if (selfPower > 0f && (threatPower / selfPower) >= fleePowerRatioThreshold)
-            {
-                CurrentTarget = threat;
-                ChangeState(FleetAIState.Flee);
-            }
-        }
-    }
-
-    private void TickSearch()
-    {
-        FleetMapController target = FindNearestHostileFleet();
-        if (target == null)
-        {
-            return;
-        }
-
         CurrentTarget = target;
-        destination = target.transform;
-        ChangeState(FleetAIState.InterceptTarget);
+        if (target != null)
+        {
+            destination = target.transform;
+        }
     }
 
-    private void TickIntercept()
+    public void ClearCurrentTarget()
     {
-        if (CurrentTarget == null || CurrentTarget.GetFleet() == null || CurrentTarget.GetFleet().getNumberBoats() <= 0)
-        {
-            CurrentTarget = null;
-            ChangeState(FleetAIState.Search);
-            return;
-        }
+        CurrentTarget = null;
+    }
 
-        destination = CurrentTarget.transform;
+    public bool HasValidCurrentTarget()
+    {
+        return CurrentTarget != null && CurrentTarget.GetFleet() != null && CurrentTarget.GetFleet().getNumberBoats() > 0;
+    }
 
-        if (GetFleetHealthRatio() < regroupHpThreshold)
+    public void SyncDestinationToCurrentTarget()
+    {
+        if (CurrentTarget != null)
         {
-            ChangeState(FleetAIState.Regroup);
+            destination = CurrentTarget.transform;
         }
     }
 
-    private void TickFlee()
+    public bool ShouldFleeFrom(FleetMapController threat)
+    {
+        if (threat == null || threat.GetFleet() == null || fleet == null)
+        {
+            return false;
+        }
+
+        float selfPower = BattlePredicter.GetFleetPower(fleet);
+        float threatPower = BattlePredicter.GetFleetPower(threat.GetFleet());
+        return selfPower > 0f && (threatPower / selfPower) >= fleePowerRatioThreshold;
+    }
+
+    public void SetDestinationToNearestFriendlyTown()
     {
         Town safeTown = FindNearestFriendlyTown();
         if (safeTown != null)
@@ -415,53 +346,14 @@ public class FleetMapController : MonoBehaviour
         }
     }
 
-    private void TickRegroup()
-    {
-        Town safeTown = FindNearestFriendlyTown();
-        if (safeTown != null)
-        {
-            destination = safeTown.transform;
-        }
-    }
-
-    private FleetMapController FindNearestHostileFleet()
+    public FleetMapController FindNearestHostileFleet()
     {
         return FindClosestFleet(CanEngage);
     }
 
     private bool CanEngage(Fleet other)
     {
-        if (other == null || fleet == null)
-        {
-            return false;
-        }
-
-        if (fleet.FleetType == AIFleetType.Pirate)
-        {
-            return other.FleetType == AIFleetType.Trade || other.FleetType == AIFleetType.NavalPatrol || other.FleetType == AIFleetType.War;
-        }
-
-        if (fleet.FleetType == AIFleetType.Trade)
-        {
-            return other.FleetType == AIFleetType.Pirate;
-        }
-
-        if (fleet.FleetType == AIFleetType.NavalPatrol)
-        {
-            return other.FleetType == AIFleetType.Pirate;
-        }
-
-        if (fleet.FleetType == AIFleetType.War)
-        {
-            if (other.FleetType == AIFleetType.Pirate)
-            {
-                return true;
-            }
-
-            return other.FleetType == AIFleetType.War && other.Nationality != fleet.Nationality;
-        }
-
-        return false;
+        return aiPolicy.CanEngage(this, other);
     }
 
     private Town FindNearestFriendlyTown()
@@ -488,7 +380,7 @@ public class FleetMapController : MonoBehaviour
         return closestTown;
     }
 
-    private float GetFleetHealthRatio()
+    public float GetFleetHealthRatio()
     {
         var boats = fleet.GetBoats();
         if (boats == null || boats.Count == 0)


### PR DESCRIPTION
### Motivation
- Separate AI "state orchestration" from per-type decision policy to avoid a monolithic `FleetMapController` full of `CanEngage`/`Tick*` logic. 
- Make per-fleet behavior easier to extend and test by moving rules into focused policy objects. 
- Keep `FleetMapController` as the runtime executor responsible for movement/pathing and world interactions while delegating decisions to policies.

### Description
- Added a new AI abstraction `IFleetAIPolicy` plus `FleetAIPolicyFactory` and concrete policy implementations `TradeFleetAIPolicy`, `PirateFleetAIPolicy`, `NavalPatrolFleetAIPolicy`, `WarFleetAIPolicy`, and `DefaultFleetAIPolicy` in `Assets/MapMode/Scripts/FleetAIPolicy.cs`. 
- `FleetMapController` now stores an `IFleetAIPolicy` instance and delegates initial state assignment via `aiPolicy.GetInitialState(this)`, per-tick logic via `aiPolicy.Tick(this)`, and encounter post-processing via `aiPolicy.UpdateAfterEncounter(...)`. 
- Moved engagement rules out of `FleetMapController` so `CanEngage` is delegated to `aiPolicy.CanEngage(...)`. 
- Exposed and added controller helpers used by policies: `SetCurrentTarget`, `ClearCurrentTarget`, `HasValidCurrentTarget`, `SyncDestinationToCurrentTarget`, `ShouldFleeFrom`, and `SetDestinationToNearestFriendlyTown`, and added a `RegroupHpThreshold` accessor. 
- Removed the old monolithic `TickTransit`/`TickSearch`/`TickIntercept`/`TickFlee`/`TickRegroup` orchestration and kept navigation as NavMesh destination-driven in `Update()`. 
- Added Unity `.meta` for the new script so it is tracked by the project.

### Testing
- Ran `git diff --check` and `git status --short` to ensure the patch is clean and files are staged, which reported no formatting issues. 
- Verified old monolithic tick handler removal with `rg -n "TickTransit|TickSearch|TickIntercept|TickFlee|TickRegroup" Assets/MapMode/Scripts/FleetMapController.cs` which returned no matches. 
- Committed the refactor with `git commit -m "Refactor fleet AI into per-type policy objects"` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69caccef85b883339858dd9a2e6bf8c4)